### PR TITLE
Update control-tower-integration.template.yaml

### DIFF
--- a/templates/control-tower-integration.template.yaml
+++ b/templates/control-tower-integration.template.yaml
@@ -356,11 +356,16 @@ Resources:
             - organizations:DescribeAccount
             Resource:
               !Join ['', ['arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':stackset/', '*' ]]
-          - Sid: StackSetInstanceDelete
+         - Sid: StackSetInstanceDelete
             Effect: Allow
             Action:
             - cloudformation:DeleteStackSet
             - cloudformation:DeleteStackInstances
+            Resource:
+              !Join ['', ['arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':stackset/', 'Lacework-*' ]]
+          - Sid: StackSetInstanceDescribeStackSetOperation
+            Effect: Allow
+            Action:
             - cloudformation:DescribeStackSetOperation
             Resource:
               !Join ['', ['arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':stackset/', '*' ]]


### PR DESCRIPTION
Due to customer feedback around Lacework broad permissions requests - limit the Sid "StackSetInstanceDelete" permissions to "lacework-*" prefixed resources only. 

Also break "StackSetInstanceDescribeStackSetOperation" out into its own Sid without the limitation