### PR TITLE
Adding an option to only setup CloudTrail

### DIFF
--- a/lambda_functions/source/setup/setup.py
+++ b/lambda_functions/source/setup/setup.py
@@ -115,11 +115,11 @@ def create(event, context):
                              audit_account_template, access_token, external_id, existing_cloudtrail)
         if "Config" in capability_type:
             setup_config(lacework_aws_account_id, lacework_url, lacework_account_name, lacework_sub_account_name,
-                        lacework_account_sns,
-                        existing_accounts,
-                        member_account_template,
-                        management_account_id,
-                        region_name, access_token, external_id, lacework_custom_sns)
+                         lacework_account_sns,
+                         existing_accounts,
+                         member_account_template,
+                         management_account_id,
+                         region_name, access_token, external_id, lacework_custom_sns)
 
     except Exception as setup_exception:
         send_cfn_fail(event, context, "Setup failed {}.".format(setup_exception))

--- a/lambda_functions/source/setup/setup.py
+++ b/lambda_functions/source/setup/setup.py
@@ -105,7 +105,7 @@ def create(event, context):
     try:
         access_token = setup_initial_access_token(lacework_url, lacework_api_credentials)
 
-        if capability_type == "CloudTrail+Config":
+        if "CloudTrail" in capability_type:
             setup_cloudtrail(lacework_aws_account_id, lacework_url, lacework_sub_account_name, region_name,
                              management_account_id,
                              log_account_name,
@@ -113,13 +113,13 @@ def create(event, context):
                              log_account_template,
                              audit_account_name,
                              audit_account_template, access_token, external_id, existing_cloudtrail)
-
-        setup_config(lacework_aws_account_id, lacework_url, lacework_account_name, lacework_sub_account_name,
-                     lacework_account_sns,
-                     existing_accounts,
-                     member_account_template,
-                     management_account_id,
-                     region_name, access_token, external_id, lacework_custom_sns)
+        if "Config" in capability_type:
+            setup_config(lacework_aws_account_id, lacework_url, lacework_account_name, lacework_sub_account_name,
+                        lacework_account_sns,
+                        existing_accounts,
+                        member_account_template,
+                        management_account_id,
+                        region_name, access_token, external_id, lacework_custom_sns)
 
     except Exception as setup_exception:
         send_cfn_fail(event, context, "Setup failed {}.".format(setup_exception))

--- a/templates/cfn-abi-control-tower-integration.template.yaml
+++ b/templates/cfn-abi-control-tower-integration.template.yaml
@@ -105,6 +105,7 @@ Parameters:
     AllowedValues:
       - 'CloudTrail+Config'
       - 'Config'
+      - 'CloudTrail'
     Type: String
     Default: CloudTrail+Config
     Description: "Enter the Lacework Control Tower StackSet type to use."

--- a/templates/control-tower-integration.template.yaml
+++ b/templates/control-tower-integration.template.yaml
@@ -105,6 +105,7 @@ Parameters:
     AllowedValues:
       - 'CloudTrail+Config'
       - 'Config'
+      - 'CloudTrail'
     Type: String
     Default: CloudTrail+Config
     Description: "Enter the Lacework Control Tower StackSet type to use."


### PR DESCRIPTION
Adding an ability for the `CapabilityType` in the master CloudFormation template to be set to `CloudTrail`, only deploying the CloudTrail integration to Lacework.

This is for customers using ControlTower and provisioning new member accounts with a parallel pipeline outside of Account Factory and EventBridge.  In this case, they do not require the `Config` integration to be deployed to the member accounts.