### PR TITLE
Revert "Bump urllib3 from 1.26.15 to 2.5.0 in /lambda_functions/source/auth"

### DIFF
--- a/lambda_functions/source/auth/requirements.txt
+++ b/lambda_functions/source/auth/requirements.txt
@@ -1,3 +1,3 @@
 crhelper
 requests
-urllib3==2.5.0
+urllib3==1.26.15


### PR DESCRIPTION
Reverts lacework-alliances/lacework-control-tower-cfn#45